### PR TITLE
Remove duplicated `disable_ddl_transaction!` on `Migration/AddIndexConcurrently` cop

### DIFF
--- a/lib/rubocop/cop/migration/add_index_concurrently.rb
+++ b/lib/rubocop/cop/migration/add_index_concurrently.rb
@@ -30,8 +30,11 @@ module RuboCop
         extend AutoCorrector
 
         include ::RuboCop::Migration::CopConcerns::DisableDdlTransaction
+        include RangeHelp
 
         MSG = 'Use `algorithm: :concurrently` on adding indexes to existing tables in PostgreSQL.'
+
+        MESSAGE_FOR_DUPLICATED_DISABLE_DDL_TRANSACTION = 'Remove duplicated `disable_ddl_transaction!`.'
 
         RESTRICT_ON_SEND = %i[
           add_index
@@ -41,10 +44,21 @@ module RuboCop
         # @param node [RuboCop::AST::SendNode]
         # @return [void]
         def on_send(node)
-          return unless bad?(node)
+          if add_index_without_concurrency?(node)
+            add_offense(node) do |corrector|
+              autocorrect(corrector, node)
+            end
+          end
 
-          add_offense(node) do |corrector|
-            autocorrect(corrector, node)
+          duplicated_disable_ddl_transactions_from(node).each do |disable_ddl_transactions_node|
+            add_offense(node, message: MESSAGE_FOR_DUPLICATED_DISABLE_DDL_TRANSACTION) do |corrector|
+              corrector.remove(
+                range_with_surrounding_space(
+                  disable_ddl_transactions_node.source_range,
+                  side: :left
+                )
+              )
+            end
           end
         end
 
@@ -116,6 +130,17 @@ module RuboCop
           )
         PATTERN
 
+        # @param node [RuboCop::AST::SendNode]
+        # @return [Boolean]
+        def add_index_without_concurrency?(node)
+          case node.method_name
+          when :add_index
+            add_index?(node) && !add_index_concurrently?(node)
+          when :index
+            index?(node) && in_change_table?(node) && !index_concurrently?(node)
+          end
+        end
+
         # @param corrector [RuboCop::Cop::Corrector]
         # @param node [RuboCop::AST::SendNode]
         # @return [void]
@@ -128,14 +153,9 @@ module RuboCop
         end
 
         # @param node [RuboCop::AST::SendNode]
-        # @return [Boolean]
-        def bad?(node)
-          case node.method_name
-          when :add_index
-            add_index?(node) && !add_index_concurrently?(node)
-          when :index
-            index?(node) && in_change_table?(node) && !index_concurrently?(node)
-          end
+        # @return [Array<RuboCop::AST::SendNode>]
+        def duplicated_disable_ddl_transactions_from(node)
+          disable_ddl_transactions_from(node)[1..] || []
         end
 
         # @param node [RuboCop::AST::SendNode]

--- a/lib/rubocop/migration/cop_concerns/disable_ddl_transaction.rb
+++ b/lib/rubocop/migration/cop_concerns/disable_ddl_transaction.rb
@@ -24,6 +24,15 @@ module RuboCop
 
         private
 
+        # @param node [RuboCop::AST::SendNode]
+        # @return [Array<RuboCop::AST::SendNode>]
+        def disable_ddl_transactions_from(node)
+          node.each_ancestor(:def).first&.left_siblings&.select do |sibling|
+            sibling.is_a?(::RuboCop::AST::SendNode) &&
+              disable_ddl_transaction?(sibling)
+          end || []
+        end
+
         # @param corrector [RuboCop::Cop::Corrector]
         # @param node [RuboCop::AST::SendNode]
         # @return [void]
@@ -40,10 +49,7 @@ module RuboCop
         # @param node [RuboCop::AST::SendNode]
         # @return [Boolean]
         def within_disable_ddl_transaction?(node)
-          node.each_ancestor(:def).first&.left_siblings&.any? do |sibling|
-            sibling.is_a?(::RuboCop::AST::SendNode) &&
-              disable_ddl_transaction?(sibling)
-          end
+          !disable_ddl_transactions_from(node).empty?
         end
       end
     end


### PR DESCRIPTION
- Fix https://github.com/r7kamura/rubocop-migration/issues/7