### PR TITLE
Fix error when table name cannot be determined at `Migration/RemoveColumn`

### DIFF
--- a/lib/rubocop/cop/migration/remove_column.rb
+++ b/lib/rubocop/cop/migration/remove_column.rb
@@ -135,15 +135,18 @@ module RuboCop
         # @param node [RuboCop::AST::SendNode]
         # @return [String, nil]
         def find_table_name_from(node)
-          node.arguments[0].value&.to_s
+          table_name_node = node.arguments[0]
+          table_name_node.value&.to_s if table_name_node.respond_to?(:value)
         end
 
+        # @note This method returns `true` if the table name cannot be determined.
         # @param node [RuboCop::AST::SendNode]
         # @return [Boolean]
         def ignored?(node)
-          find_ignored_column_names_from(
-            find_table_name_from(node)
-          ).include?(
+          table_name = find_table_name_from(node)
+          return true unless table_name
+
+          find_ignored_column_names_from(table_name).include?(
             find_column_name_from(node)
           )
         end

--- a/spec/rubocop/cop/migration/remove_column_spec.rb
+++ b/spec/rubocop/cop/migration/remove_column_spec.rb
@@ -96,4 +96,16 @@ RSpec.describe RuboCop::Cop::Migration::RemoveColumn, :config do
       RUBY
     end
   end
+
+  context 'when table name is non literal node' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class RemoveSomeColumn < ActiveRecord::Migration[7.0]
+          def change
+            remove_column table_name, :some_column
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
- Fix https://github.com/r7kamura/rubocop-migration/issues/11